### PR TITLE
Simplified variables (defaulting some to var.cluster_name)

### DIFF
--- a/azurerm_kubernetes_cluster/README.md
+++ b/azurerm_kubernetes_cluster/README.md
@@ -30,29 +30,36 @@ variable "client_secret" {
   type        = string
   description = "Kubernetes service principal client secret and azurerm provider client_secret"
 }
-variable "dns_prefix" {
-  type        = string
-  description = "DNS prefix of the 'azurerm_kubernetes_cluster'"
-}
 variable "cluster_name" {
   type        = string
   description = "The name of the 'azurerm_kubernetes_cluster'"
-}
-variable "resource_group" {
-  type        = string
-  description = "The name of the resource group within the virtual network"
 }
 variable "location" {
   type        = string
   description = "The location of the kubernetes cluster deployment"
 }
+```
+## Optional variables
+### Defaulting to var.cluster_name
+```hcl
+variable "resource_group" {
+  type        = string
+  description = "The name of the resource group within the virtual network"
+  default     = ""
+}
 variable "log_analytics_workspace_name" {
   type        = string
   description = "The name of the Log Analytics Workspace"
+  default     = ""
+}
+variable "dns_prefix" {
+  type        = string
+  description = "DNS prefix of the 'azurerm_kubernetes_cluster'"
+  default     = ""
 }
 ```
-## Optional variables
 ```hcl
+### Predefined values
 variable "tags" {
   type        = map(string)
   description = "Tags to assign to the 'azurerm_kubernetes_cluster'"
@@ -105,10 +112,7 @@ variables:
   subscription_id: "<%= ENV['AZURE_SUBSCRIPTION_ID'] %>"
   tenant_id: "<%= ENV['AZURE_TENANT_ID'] %>"
   cluster_name: "kitchen-test"
-  dns_prefix: "kitchen-dns"
   location: "northeurope"
-  log_analytics_workspace_name: "kitchen-ws"
-  resource_group: "kitchen-rg"
   
 provisioner:
   name: terraform

--- a/azurerm_kubernetes_cluster/aks.tf
+++ b/azurerm_kubernetes_cluster/aks.tf
@@ -1,6 +1,6 @@
 # creating dedicated resource group for kubernetes
 resource "azurerm_resource_group" "k8s" {
-  name     = var.resource_group
+  name     = local.resource_group
   location = var.location
 }
 
@@ -11,7 +11,7 @@ resource "random_id" "log_analytics_workspace_name_suffix" {
 
 # create a Log Analytics (formally Operational Insights) Workspace
 resource "azurerm_log_analytics_workspace" "log-workspace" {
-  name                = "${var.log_analytics_workspace_name}-${random_id.log_analytics_workspace_name_suffix.dec}"
+  name                = "${local.log_analytics_workspace_name}-${random_id.log_analytics_workspace_name_suffix.dec}"
   location            = var.location
   resource_group_name = azurerm_resource_group.k8s.name
   sku                 = var.log_analytics_workspace_sku
@@ -35,7 +35,7 @@ resource "azurerm_kubernetes_cluster" "k8s" {
   name                = var.cluster_name
   location            = azurerm_resource_group.k8s.location
   resource_group_name = azurerm_resource_group.k8s.name
-  dns_prefix          = var.dns_prefix
+  dns_prefix          = local.dns_prefix
   kubernetes_version  = var.kubernetes_version
 
   agent_pool_profile {

--- a/azurerm_kubernetes_cluster/main.tf
+++ b/azurerm_kubernetes_cluster/main.tf
@@ -10,3 +10,10 @@ terraform {
   required_version = ">= 0.12"
   backend "local" {}
 }
+
+locals {
+  # if variables not defined, then use var.cluster_name
+  resource_group               = var.resource_group != "" var.resource_group : var.cluster_name
+  log_analytics_workspace_name = var.log_analytics_workspace_name != "" var.log_analytics_workspace_name : var.cluster_name
+  dns_prefix                   = var.dns_prefix != "" var.dns_prefix : var.cluster_name
+}

--- a/azurerm_kubernetes_cluster/variables.tf
+++ b/azurerm_kubernetes_cluster/variables.tf
@@ -15,28 +15,33 @@ variable "client_secret" {
   type        = string
   description = "Kubernetes service principal client secret and azurerm provider client_secret"
 }
-variable "dns_prefix" {
-  type        = string
-  description = "DNS prefix of the 'azurerm_kubernetes_cluster'"
-}
 variable "cluster_name" {
   type        = string
   description = "The name of the 'azurerm_kubernetes_cluster'"
 }
+variable "location" {
+  type        = string
+  description = "The location of the kubernetes cluster deployment"
+}
+
+### optional vars (defaulting to var.cluster_name) ###
 variable "resource_group" {
   type        = string
   description = "The name of the resource group within the virtual network"
-}
-variable "location" {
-  type        = string
-  description = "The location of the kubernetes clutser deployment"
+  default     = ""
 }
 variable "log_analytics_workspace_name" {
-  type = string
+  type        = string
   description = "The name of the Log Analytics Workspace"
+  default     = ""
+}
+variable "dns_prefix" {
+  type        = string
+  description = "DNS prefix of the 'azurerm_kubernetes_cluster'"
+  default     = ""
 }
 
-### optional vars ###
+### optional vars  ###
 variable "tags" {
   type        = map(string)
   description = "Tags to assign to the 'azurerm_kubernetes_cluster'"


### PR DESCRIPTION
Defaulting to `var.cluster_name`  for the following variables in case it is not specified
* `resource_group`
* `log_analytics_workspace_name`
* `dns_prefix`

The `var.location` is currently not handled this way, because I was not able to find any `data` source that could fetch the possible locations based on the authenticated provider.
The following variables are still mandatory to specify:
* `client_id`
* `client_secret`
* `subscription_id`
* `tenant_id`
* `cluster_name`
* `location`
