### PR TITLE
Rename gke vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Basic usage looks like this:
 
 ```hcl
 module "k8s" {
-  source  = "git::https://github.com/kyma-incubator/terraform-modules//google_gke_infra?ref=v0.0.1"
+  source  = "git::https://github.com/kyma-incubator/terraform-modules//google_gke_infra?ref=v0.0.2"
   name    = "${var.cluster_name}"
   project = "${var.project}"
   region  = "${var.region}"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Basic usage looks like this:
 ```hcl
 module "k8s" {
   source  = "git::https://github.com/kyma-incubator/terraform-modules//google_gke_infra?ref=v0.0.1"
-  name    = "${var.name}"
+  name    = "${var.cluster_name}"
   project = "${var.project}"
   region  = "${var.region}"
 }

--- a/google_gke_infra/README.md
+++ b/google_gke_infra/README.md
@@ -98,7 +98,7 @@ Have a look at the basic Terraform module configuration:
 ```hcl
 module "k8s" {
   source  = "git::https://github.com/kyma-incubator/terraform-modules//google_gke_infra?ref=v0.0.1"
-  name    = "${var.name}"
+  name    = "${var.cluster_name}"
   project = "${var.project}"
   region  = "${var.region}"
   private_nodes = true  # This will disable public IPs from the nodes
@@ -176,8 +176,8 @@ For details on variables, see the [this](variables.tf) file.
 
 | Variable  | Description                                  |
 | :-------- | :------------------------------------------- |
-| **name**   | The name to use as a prefix for all the resources. |
-| **region**  | The region that hosts the cluster. Each Node will be put in a different availability zone in the region for HA. |
+| **cluster_name** | The name to use as a prefix for all the resources. |
+| **region**       | The region that hosts the cluster. Each Node will be put in a different availability zone in the region for HA. |
 
 ### Optional variables
 

--- a/google_gke_infra/README.md
+++ b/google_gke_infra/README.md
@@ -158,7 +158,7 @@ The GKE module exposes two variables to allow the separate upgrade of the Contro
 
 #### Update **k8s_version**
 
->**NOTE:** This value configures the version of the Control Plane. You must upgrade it first. 
+>**NOTE:** This value configures the version of the Control Plane. You must upgrade it first.
 
 The updating operation takes about 15 minutes. Once it is done, re-run `terraform plan` to validate that Terraform does not need any further changes. If the node pools are configured for auto upgrade, GCP automatically upgrades the Nodes within the upcoming weeks to match the master version, so that you don't need to manually adjust the **node_version**.
 
@@ -185,7 +185,7 @@ For details on variables, see the [this](variables.tf) file.
 | :------------------------- | :---------------------------------- | :---------------------------------------------------- |
 | **project**                  | The ID of the Google project to which the resource belongs. | Value configured in `gcloud` client. |
 | **description**             | A description to apply to all resources. | `Managed by Terraform` |
-| **google_credentials**      | Either the path to or the contents of a service account key file in JSON format. | `null` |
+| **credentials_file_path**    | Either the path to or the contents of a service account key file in JSON format. | `null` |
 | **google_access_token**      | A temporary OAuth 2.0 access token obtained from the Google Authorization server, i.e. the Authorization: Bearer token used to authenticate HTTP requests to GCP APIs. | `null` |
 | **enable_legacy_kubeconfig** | Specifies whether to enable authentication using tokens/passwords/certificates or not. | `false` |
 | **k8s_version**              | Default Kubernetes version for the Control Plane. | `1.14` |

--- a/google_gke_infra/README.md
+++ b/google_gke_infra/README.md
@@ -188,7 +188,7 @@ For details on variables, see the [this](variables.tf) file.
 | **credentials_file_path**    | Either the path to or the contents of a service account key file in JSON format. | `null` |
 | **google_access_token**      | A temporary OAuth 2.0 access token obtained from the Google Authorization server, i.e. the Authorization: Bearer token used to authenticate HTTP requests to GCP APIs. | `null` |
 | **enable_legacy_kubeconfig** | Specifies whether to enable authentication using tokens/passwords/certificates or not. | `false` |
-| **kubernetes_version**       | Default Kubernetes version for the Control Plane. | `1.14` |
+| **kubernetes_version**       | Default Kubernetes version for the Control Plane. | `1.15` |
 | **private_nodes**            | Specifies whether to create a private cluster or not. This will remove public IPs from your Nodes and create a NAT Gateway/CloudNAT to allow internet access. | `true` |
 | **private_masters**          | If true, the Kubernetes API endpoint will not be public. This is still work in progress. **Do not use**. | `false` |
 | **gcloud_path**             | The path to your gcloud client binary. | `gcloud` |

--- a/google_gke_infra/README.md
+++ b/google_gke_infra/README.md
@@ -12,7 +12,7 @@ Use the following links to navigate through the document.
     - [Use the cluster as a Terraform provider](#use-the-cluster-as-a-terraform-provider)
     - [Deploy custom Kubernets resources](#deploy-custom-kubernetes-resources)
     - [Upgrade a cluster](#upgrade-a-cluster)
-      - [Update **k8s_version**](#update-k8sversion)
+      - [Update **kubernetes_version**](#update-kubernetes-version)
       - [Update **node_version**](#update-nodeversion)
   - [Variables](#variables)
     - [Required variables](#required-variables)
@@ -156,7 +156,7 @@ module "k8s" {
 
 The GKE module exposes two variables to allow the separate upgrade of the Control Plane and Nodes.
 
-#### Update **k8s_version**
+#### Update **kubernetes-version**
 
 >**NOTE:** This value configures the version of the Control Plane. You must upgrade it first.
 
@@ -188,7 +188,7 @@ For details on variables, see the [this](variables.tf) file.
 | **credentials_file_path**    | Either the path to or the contents of a service account key file in JSON format. | `null` |
 | **google_access_token**      | A temporary OAuth 2.0 access token obtained from the Google Authorization server, i.e. the Authorization: Bearer token used to authenticate HTTP requests to GCP APIs. | `null` |
 | **enable_legacy_kubeconfig** | Specifies whether to enable authentication using tokens/passwords/certificates or not. | `false` |
-| **k8s_version**              | Default Kubernetes version for the Control Plane. | `1.14` |
+| **kubernetes_version**       | Default Kubernetes version for the Control Plane. | `1.14` |
 | **private_nodes**            | Specifies whether to create a private cluster or not. This will remove public IPs from your Nodes and create a NAT Gateway/CloudNAT to allow internet access. | `true` |
 | **private_masters**          | If true, the Kubernetes API endpoint will not be public. This is still work in progress. **Do not use**. | `false` |
 | **gcloud_path**             | The path to your gcloud client binary. | `gcloud` |

--- a/google_gke_infra/README.md
+++ b/google_gke_infra/README.md
@@ -97,7 +97,7 @@ Have a look at the basic Terraform module configuration:
 
 ```hcl
 module "k8s" {
-  source  = "git::https://github.com/kyma-incubator/terraform-modules//google_gke_infra?ref=v0.0.1"
+  source  = "git::https://github.com/kyma-incubator/terraform-modules//google_gke_infra?ref=v0.0.2"
   name    = "${var.cluster_name}"
   project = "${var.project}"
   region  = "${var.region}"

--- a/google_gke_infra/README.md
+++ b/google_gke_infra/README.md
@@ -311,9 +311,9 @@ Configurable timeout values for the various cluster operations.
 
 | Variable  | Description                                         | Default  |
 | :-------- | :-------------------------------------------------- | :------- |
-| **create**  | The default timeout for a cluster create operation. | `20m` |
-| **update**  | The default timeout for a cluster update operation. | `360m` |
-| **delete**  | The default timeout for a cluster delete operation. | `20m` |
+| **create_timeout**  | The default timeout for a cluster create operation. | `20m` |
+| **update_timeout**  | The default timeout for a cluster update operation. | `360m` |
+| **delete_timeout**  | The default timeout for a cluster delete operation. | `20m` |
 
 ### Output Variables
 

--- a/google_gke_infra/outputs.tf
+++ b/google_gke_infra/outputs.tf
@@ -67,18 +67,18 @@ clusters:
 - cluster:
     server: https://${google_container_cluster.cluster.endpoint}
     certificate-authority-data: ${google_container_cluster.cluster.master_auth[0].cluster_ca_certificate}
-  name: gke-${var.name}
+  name: gke-${var.cluster_name}
 users:
-- name: gke-${var.name}
+- name: gke-${var.cluster_name}
   user:
     client-certificate-data: ${google_container_cluster.cluster.master_auth[0].client_certificate}
     client-key-data: ${google_container_cluster.cluster.master_auth[0].client_key}
 contexts:
 - context:
-    cluster: gke-${var.name}
-    user: gke-${var.name}
-  name: gke-${var.name}
-current-context: gke-${var.name}
+    cluster: gke-${var.cluster_name}
+    user: gke-${var.cluster_name}
+  name: gke-${var.cluster_name}
+current-context: gke-${var.cluster_name}
 
 KUBECONFIG
 
@@ -92,9 +92,9 @@ clusters:
 - cluster:
     server: https://${google_container_cluster.cluster.endpoint}
     certificate-authority-data: ${google_container_cluster.cluster.master_auth[0].cluster_ca_certificate}
-  name: gke-${var.name}
+  name: gke-${var.cluster_name}
 users:
-- name: gke-${var.name}
+- name: gke-${var.cluster_name}
   user:
     auth-provider:
       config:
@@ -105,10 +105,10 @@ users:
       name: gcp
 contexts:
 - context:
-    cluster: gke-${var.name}
-    user: gke-${var.name}
-  name: gke-${var.name}
-current-context: gke-${var.name}
+    cluster: gke-${var.cluster_name}
+    user: gke-${var.cluster_name}
+  name: gke-${var.cluster_name}
+current-context: gke-${var.cluster_name}
 
 KUBECONFIG
 }

--- a/google_gke_infra/tf-gke.tf
+++ b/google_gke_infra/tf-gke.tf
@@ -15,7 +15,7 @@ resource "google_container_cluster" "cluster" {
   enable_tpu                  = lookup(var.extras, "enable_tpu", false)
   enable_legacy_abac          = var.enable_legacy_kubeconfig
   logging_service             = lookup(var.k8s_options, "logging_service", "none")
-  min_master_version          = var.k8s_version
+  min_master_version          = var.kubernetes_version
   monitoring_service          = lookup(var.k8s_options, "monitoring_service", "none")
   remove_default_node_pool    = var.remove_default_node_pool
   # workload_identity_config = # TODO

--- a/google_gke_infra/tf-gke.tf
+++ b/google_gke_infra/tf-gke.tf
@@ -2,7 +2,7 @@
 ##########################################################
 resource "google_container_cluster" "cluster" {
   provider                    = google-beta
-  name                        = var.name
+  name                        = var.cluster_name
   project                     = var.project
   location                    = var.region
   network                     = local.network_link
@@ -82,8 +82,8 @@ resource "google_container_cluster" "cluster" {
   }
 
   ip_allocation_policy {
-    cluster_secondary_range_name  = "${var.name}-k8s-pod"
-    services_secondary_range_name = "${var.name}-k8s-svc"
+    cluster_secondary_range_name  = "${var.cluster_name}-k8s-pod"
+    services_secondary_range_name = "${var.cluster_name}-k8s-svc"
   }
 
   lifecycle {
@@ -170,7 +170,7 @@ resource "google_container_node_pool" "pools" {
   count              = length(var.node_pools)
   project            = var.project
   location           = var.region
-  name               = lookup(var.node_pools[count.index], "name", format("%s-%d", var.name, count.index))
+  name               = lookup(var.node_pools[count.index], "name", format("%s-%d", var.cluster_name, count.index))
   initial_node_count = lookup(var.node_pools[count.index], "initial_node_count", 1)
   max_pods_per_node  = lookup(var.node_pools[count.index], "max_pods_per_node", 110)
   # Node version rules:
@@ -208,7 +208,7 @@ resource "google_container_node_pool" "pools" {
     oauth_scopes    = var.oauth_scopes
     preemptible     = lookup(var.node_pools[count.index], "preemptible", false)
     service_account = var.service_account == null ? google_service_account.sa[0].email : var.service_account
-    tags            = concat(list(var.name), lookup(var.node_pools[count.index], "node_tags", []))
+    tags            = concat(list(var.cluster_name), lookup(var.node_pools[count.index], "node_tags", []))
 
 
     # TODO add option to define flexible taints map for each pool if needed.

--- a/google_gke_infra/tf-gke.tf
+++ b/google_gke_infra/tf-gke.tf
@@ -152,9 +152,9 @@ resource "google_container_cluster" "cluster" {
   # }
 
   timeouts {
-    create = var.timeouts["create"]
-    update = var.timeouts["update"]
-    delete = var.timeouts["delete"]
+    create = var.timeouts["create_timeout"]
+    update = var.timeouts["update_timeout"]
+    delete = var.timeouts["delete_timeout"]
   }
 
   vertical_pod_autoscaling {
@@ -220,8 +220,8 @@ resource "google_container_node_pool" "pools" {
   }
 
   timeouts {
-    create = var.timeouts["create"]
-    update = var.timeouts["update"]
-    delete = var.timeouts["delete"]
+    create = var.timeouts["create_timeout"]
+    update = var.timeouts["update_timeout"]
+    delete = var.timeouts["delete_timeout"]
   }
 }

--- a/google_gke_infra/tf-main.tf
+++ b/google_gke_infra/tf-main.tf
@@ -7,7 +7,7 @@ terraform {
 provider "google" {
   version      = "~> 2.7"
   region       = var.region
-  credentials  = var.google_credentials
+  credentials  = var.credentials_file_path
   access_token = var.google_access_token
 }
 
@@ -16,7 +16,7 @@ provider "google" {
 provider "google-beta" {
   version      = "~> 2.7"
   region       = var.region
-  credentials  = var.google_credentials
+  credentials  = var.credentials_file_path
   access_token = var.google_access_token
 }
 

--- a/google_gke_infra/tf-main.tf
+++ b/google_gke_infra/tf-main.tf
@@ -28,7 +28,7 @@ data "google_client_config" "gcloud" {}
 ##########################################################
 resource "google_compute_network" "vpc" {
   count                   = var.network_name == null ? 1 : 0
-  name                    = var.name
+  name                    = var.cluster_name
   project                 = var.project
   auto_create_subnetworks = "false"
 }
@@ -36,7 +36,7 @@ resource "google_compute_network" "vpc" {
 # Subnets
 ##########################################################
 resource "google_compute_subnetwork" "subnet" {
-  name                     = var.name
+  name                     = var.cluster_name
   project                  = var.project
   network                  = local.network_link
   region                   = var.region
@@ -46,12 +46,12 @@ resource "google_compute_subnetwork" "subnet" {
 
   # enable_flow_logs = "${var.enable_flow_logs}" # TODO
   secondary_ip_range {
-    range_name    = "${var.name}-k8s-pod"
+    range_name    = "${var.cluster_name}-k8s-pod"
     ip_cidr_range = var.k8s_ip_ranges["pod_cidr"]
   }
 
   secondary_ip_range {
-    range_name    = "${var.name}-k8s-svc"
+    range_name    = "${var.cluster_name}-k8s-svc"
     ip_cidr_range = var.k8s_ip_ranges["svc_cidr"]
   }
 }
@@ -60,8 +60,8 @@ resource "google_compute_subnetwork" "subnet" {
 ##########################################################
 resource "google_service_account" "sa" {
   count        = var.service_account == null ? 1 : 0
-  account_id   = var.name
-  display_name = "${var.name} SA"
+  account_id   = var.cluster_name
+  display_name = "${var.cluster_name} SA"
   project      = var.project
 }
 

--- a/google_gke_infra/variables-maps.tf
+++ b/google_gke_infra/variables-maps.tf
@@ -59,8 +59,8 @@ variable "timeouts" {
   description = "Configurable timeout values for the various cluster operations."
 
   default = {
-    create = "20m"  # The default timeout for a cluster create operation.
-    update = "360m" # The default timeout for a cluster update operation (6 hours - node upgrades can take a long time)
-    delete = "20m"  # The default timeout for a cluster delete operation.
+    create_timeout = "20m"  # The default timeout for a cluster create operation.
+    update_timeout = "360m" # The default timeout for a cluster update operation (6 hours - node upgrades can take a long time)
+    delete_timeout = "20m"  # The default timeout for a cluster delete operation.
   }
 }

--- a/google_gke_infra/variables.tf
+++ b/google_gke_infra/variables.tf
@@ -37,7 +37,7 @@ variable "enable_legacy_kubeconfig" {
 
 variable "kubernetes_version" {
   description = "Default K8s version for the Control Plane. See: https://www.terraform.io/docs/providers/google/r/container_cluster.html#min_master_version"
-  default     = "1.14"
+  default     = "1.15"
 }
 
 variable "private_nodes" {

--- a/google_gke_infra/variables.tf
+++ b/google_gke_infra/variables.tf
@@ -35,7 +35,7 @@ variable "enable_legacy_kubeconfig" {
   default     = false
 }
 
-variable "k8s_version" {
+variable "kubernetes_version" {
   description = "Default K8s version for the Control Plane. See: https://www.terraform.io/docs/providers/google/r/container_cluster.html#min_master_version"
   default     = "1.14"
 }

--- a/google_gke_infra/variables.tf
+++ b/google_gke_infra/variables.tf
@@ -1,6 +1,6 @@
 # Required
 ##########################################################
-variable "name" {
+variable "cluster_name" {
   description = "Name to use as a prefix to all the resources."
 }
 

--- a/google_gke_infra/variables.tf
+++ b/google_gke_infra/variables.tf
@@ -19,7 +19,7 @@ variable "description" {
   default = "Managed by Terraform"
 }
 
-variable "google_credentials" {
+variable "credentials_file_path" {
   description = "Either the path to or the contents of a service account key file in JSON format."
   default     = null
 }


### PR DESCRIPTION
The following variables are being renamed in this PR:

- `google_credentials` -> `credentials_file_path`
- `name` -> `cluster_name`
- `k8s_version` -> `kubernetes_version`
- `create`,`update`,`delete` timeout vars are now all suffixed with `_timeout`

This PR also bumps the default Kubernetes version to `1.15` and increments the module reference tag to `v0.0.2` in the documentation